### PR TITLE
Flux delete sync event

### DIFF
--- a/pkg/exporters/slack_test.go
+++ b/pkg/exporters/slack_test.go
@@ -132,7 +132,7 @@ func TestNewSlackMessageNoIDs(t *testing.T) {
 		Title:     "The title of the message",
 		Body:      "this is the message body",
 		Event: fluxevent.Event{
-			ServiceIDs: []flux.ResourceID{},
+			ServiceIDs: []resource.ID{},
 		},
 	}
 

--- a/pkg/exporters/slack_test.go
+++ b/pkg/exporters/slack_test.go
@@ -126,6 +126,29 @@ func TestNewSlackMessage(t *testing.T) {
 	assert.Equal(t, message.Title, attach.Title)
 }
 
+func TestNewSlackMessageNoIDs(t *testing.T) {
+	message := msg.Message{
+		TitleLink: "https://myvcslink/",
+		Title:     "The title of the message",
+		Body:      "this is the message body",
+		Event: fluxevent.Event{
+			ServiceIDs: []flux.ResourceID{},
+		},
+	}
+
+	slackMessages := testSlack.NewSlackMessage(message)
+	assert.Len(t, slackMessages, 1)
+
+	assert.Equal(t, "#channel", slackMessages[0].Channel)
+	assert.Equal(t, testSlack.IconEmoji, slackMessages[0].IconEmoji)
+	assert.Equal(t, testSlack.Username, slackMessages[0].Username)
+
+	attach := slackMessages[0].Attachments[0]
+	assert.Equal(t, "#4286f4", attach.Color)
+	assert.Equal(t, message.TitleLink, attach.TitleLink)
+	assert.Equal(t, message.Title, attach.Title)
+}
+
 func TestSlackSend(t *testing.T) {
 	resourceID, _ := flux.ParseResourceID("namespace:resource/name")
 	message := msg.Message{

--- a/pkg/formatters/default.go
+++ b/pkg/formatters/default.go
@@ -129,10 +129,6 @@ func NewDefaultFormatter(config config.Config) (*DefaultFormatter, error) {
 
 // Format plaintext message for an exporter for Flux event
 func (d DefaultFormatter) FormatEvent(event fluxevent.Event, exporter exporters.Exporter) msg.Message {
-	if len(event.ServiceIDs) == 0 {
-		return msg.Message{}
-	}
-
 	values := &tplValues{
 		VCSLink:            d.vcsLink,
 		EventID:            event.ID,

--- a/pkg/formatters/default_test.go
+++ b/pkg/formatters/default_test.go
@@ -87,6 +87,26 @@ Resources updated:
 	assert.Equal(t, event, msg.Event)
 }
 
+func TestDefaultFormatterFormatDeleteSyncEvent(t *testing.T) {
+	d := DefaultFormatter{
+		vcsLink:        "https://github.com",
+		bodyTemplate:   bodyTemplate,
+		titleTemplate:  titleTemplate,
+		commitTemplate: commitTemplate,
+	}
+
+	event := test_utils.NewFluxDeleteEvent()
+	msg := d.FormatEvent(event, &exporters.FakeExporter{})
+	assert.Equal(t, "https://github.com/commit/c6b7c44b4300f92b788bbc9bb6cb7282852300b4", msg.TitleLink)
+	assert.Equal(t, "Applied flux changes to cluster", msg.Title)
+	assert.Equal(t, fluxevent.EventSync, msg.Type)
+	assert.Equal(t, `Event: Sync: c6b7c44, no workloads changed
+Commits:
+
+* <https://github.com/commit/c6b7c44b4300f92b788bbc9bb6cb7282852300b4|c6b7c44>: deleted k8s-global-objects`, msg.Body)
+	assert.Equal(t, event, msg.Event)
+}
+
 func TestDefaultFormatterFormatCommitEvent(t *testing.T) {
 	d := DefaultFormatter{
 		vcsLink:        "https://github.com",

--- a/pkg/utils/test/utils.go
+++ b/pkg/utils/test/utils.go
@@ -175,3 +175,26 @@ func NewFluxUpdatePolicyEvent() fluxevent.Event {
 }`))
 	return event
 }
+
+func NewFluxDeleteEvent() fluxevent.Event {
+	event, _ := utils.ParseFluxEvent(bytes.NewBufferString(`{
+  "id":0,
+  "serviceIDs":[],
+  "type":"sync",
+  "startedAt":"2020-03-17T18:56:29.941174734Z",
+  "endedAt":"2020-03-17T18:56:29.941174734Z",
+  "logLevel":"info",
+  "metadata":{
+	"commits":[
+	  {
+		"revision":"c6b7c44b4300f92b788bbc9bb6cb7282852300b4",
+		"message":"deleted k8s-global-objects"
+	  }
+	],
+	"includes":{
+	  "other":true
+	}
+  }
+}`))
+	return event
+}

--- a/pkg/utils/test/utils_test.go
+++ b/pkg/utils/test/utils_test.go
@@ -23,6 +23,23 @@ func TestParseFluxEventSync(t *testing.T) {
 	assert.Equal(t, true, metadata.Includes["other"])
 }
 
+func TestParseFluxEventDeleteSync(t *testing.T) {
+	event := NewFluxDeleteEvent()
+
+	assert.Equal(t, fluxevent.EventSync, event.Type)
+
+	assert.Equal(t, fluxevent.EventID(0), event.ID)
+	assert.Len(t, event.ServiceIDs, 0)
+	assert.Equal(t, "info", event.LogLevel)
+
+	metadata := event.Metadata.(*fluxevent.SyncEventMetadata)
+	commit := metadata.Commits[0]
+
+	assert.Equal(t, "c6b7c44b4300f92b788bbc9bb6cb7282852300b4", commit.Revision)
+	assert.Equal(t, "deleted k8s-global-objects", commit.Message)
+	assert.Equal(t, true, metadata.Includes["other"])
+}
+
 func TestParseFluxEventCommit(t *testing.T) {
 	event := NewFluxCommitEvent()
 


### PR DESCRIPTION
Flux supports the deletion of objects, its just like a regular sync event but it has no serviceID's, the existing code was strictly checking for serviceID's and slack messages were dependent on serviceID's as well. This commit is to add no serviceID support (aka, flux delete sync event)