### PR TITLE
Add cluster name as an optional config and to the default title template

### DIFF
--- a/pkg/formatters/default_test.go
+++ b/pkg/formatters/default_test.go
@@ -70,14 +70,13 @@ func TestDefaultFormatterFormatSyncEvent(t *testing.T) {
 		bodyTemplate:   bodyTemplate,
 		titleTemplate:  titleTemplate,
 		commitTemplate: commitTemplate,
-		cluster:        "cluster-name",
 	}
 
 	event := test_utils.NewFluxSyncEvent()
 
 	msg := d.FormatEvent(event, &exporters.FakeExporter{})
 	assert.Equal(t, "https://github.com/commit/810c2e6f22ac5ab7c831fe0dd697fe32997b098f", msg.TitleLink)
-	assert.Equal(t, "Applied flux changes to cluster cluster-name", msg.Title)
+	assert.Equal(t, "Applied flux changes to cluster", msg.Title)
 	assert.Equal(t, fluxevent.EventSync, msg.Type)
 	assert.Equal(t, `Event: Sync: 810c2e6, default:deployment/test
 Commits:
@@ -96,13 +95,12 @@ func TestDefaultFormatterFormatDeleteSyncEvent(t *testing.T) {
 		bodyTemplate:   bodyTemplate,
 		titleTemplate:  titleTemplate,
 		commitTemplate: commitTemplate,
-		cluster:        "cluster-name",
 	}
 
 	event := test_utils.NewFluxDeleteEvent()
 	msg := d.FormatEvent(event, &exporters.FakeExporter{})
 	assert.Equal(t, "https://github.com/commit/c6b7c44b4300f92b788bbc9bb6cb7282852300b4", msg.TitleLink)
-	assert.Equal(t, "Applied flux changes to cluster cluster-name", msg.Title)
+	assert.Equal(t, "Applied flux changes to cluster", msg.Title)
 	assert.Equal(t, fluxevent.EventSync, msg.Type)
 	assert.Equal(t, `Event: Sync: c6b7c44, no workloads changed
 Commits:
@@ -117,11 +115,10 @@ func TestDefaultFormatterFormatCommitEvent(t *testing.T) {
 		bodyTemplate:   bodyTemplate,
 		titleTemplate:  titleTemplate,
 		commitTemplate: commitTemplate,
-		cluster:        "cluster-name",
 	}
 	msg := d.FormatEvent(test_utils.NewFluxCommitEvent(), &exporters.FakeExporter{})
 	assert.Equal(t, "https://github.com/commit/d644e1a05db6881abf0cdb78299917b95f442036", msg.TitleLink)
-	assert.Equal(t, "Applied flux changes to cluster cluster-name", msg.Title)
+	assert.Equal(t, "Applied flux changes to cluster", msg.Title)
 	assert.Equal(t, fluxevent.EventCommit, msg.Type)
 	assert.Equal(t, `Event: Commit: d644e1a, default:deployment/test
 

--- a/pkg/formatters/default_test.go
+++ b/pkg/formatters/default_test.go
@@ -26,6 +26,7 @@ func TestNewDefaultFormatter(t *testing.T) {
 func TestNewDefaultFormatterCustom(t *testing.T) {
 	config := config.NewFakeConfig()
 	config.Set("github_url", "https://github.com/")
+	config.Set("cluster", "cluster-name")
 
 	bodyTemplate := `
 {{ if or (eq .EventType "commit") (eq .EventType "autorelease")}}
@@ -49,6 +50,7 @@ func TestNewDefaultFormatterCustom(t *testing.T) {
 	assert.Equal(t, commitTemplate, formatter.commitTemplate)
 	assert.Equal(t, "https://github.com/", formatter.vcsLink)
 	assert.Equal(t, config, formatter.config)
+	assert.Equal(t, "cluster-name", formatter.cluster)
 }
 
 func TestNewDefaultFormatterNoGithubLink(t *testing.T) {
@@ -68,13 +70,14 @@ func TestDefaultFormatterFormatSyncEvent(t *testing.T) {
 		bodyTemplate:   bodyTemplate,
 		titleTemplate:  titleTemplate,
 		commitTemplate: commitTemplate,
+		cluster:        "cluster-name",
 	}
 
 	event := test_utils.NewFluxSyncEvent()
 
 	msg := d.FormatEvent(event, &exporters.FakeExporter{})
 	assert.Equal(t, "https://github.com/commit/810c2e6f22ac5ab7c831fe0dd697fe32997b098f", msg.TitleLink)
-	assert.Equal(t, "Applied flux changes to cluster", msg.Title)
+	assert.Equal(t, "Applied flux changes to cluster cluster-name", msg.Title)
 	assert.Equal(t, fluxevent.EventSync, msg.Type)
 	assert.Equal(t, `Event: Sync: 810c2e6, default:deployment/test
 Commits:
@@ -93,12 +96,13 @@ func TestDefaultFormatterFormatDeleteSyncEvent(t *testing.T) {
 		bodyTemplate:   bodyTemplate,
 		titleTemplate:  titleTemplate,
 		commitTemplate: commitTemplate,
+		cluster:        "cluster-name",
 	}
 
 	event := test_utils.NewFluxDeleteEvent()
 	msg := d.FormatEvent(event, &exporters.FakeExporter{})
 	assert.Equal(t, "https://github.com/commit/c6b7c44b4300f92b788bbc9bb6cb7282852300b4", msg.TitleLink)
-	assert.Equal(t, "Applied flux changes to cluster", msg.Title)
+	assert.Equal(t, "Applied flux changes to cluster cluster-name", msg.Title)
 	assert.Equal(t, fluxevent.EventSync, msg.Type)
 	assert.Equal(t, `Event: Sync: c6b7c44, no workloads changed
 Commits:
@@ -113,10 +117,11 @@ func TestDefaultFormatterFormatCommitEvent(t *testing.T) {
 		bodyTemplate:   bodyTemplate,
 		titleTemplate:  titleTemplate,
 		commitTemplate: commitTemplate,
+		cluster:        "cluster-name",
 	}
 	msg := d.FormatEvent(test_utils.NewFluxCommitEvent(), &exporters.FakeExporter{})
 	assert.Equal(t, "https://github.com/commit/d644e1a05db6881abf0cdb78299917b95f442036", msg.TitleLink)
-	assert.Equal(t, "Applied flux changes to cluster", msg.Title)
+	assert.Equal(t, "Applied flux changes to cluster cluster-name", msg.Title)
 	assert.Equal(t, fluxevent.EventCommit, msg.Type)
 	assert.Equal(t, `Event: Commit: d644e1a, default:deployment/test
 
@@ -167,10 +172,11 @@ func TestDefaultFormatterFormatAutoReleaseEvent(t *testing.T) {
 		bodyTemplate:   bodyTemplate,
 		titleTemplate:  titleTemplate,
 		commitTemplate: commitTemplate,
+		cluster:        "cluster-name",
 	}
 	msg := d.FormatEvent(test_utils.NewFluxAutoReleaseEvent(), &exporters.FakeExporter{})
 	assert.Equal(t, "https://github.com", msg.TitleLink)
-	assert.Equal(t, "Applied flux changes to cluster", msg.Title)
+	assert.Equal(t, "Applied flux changes to cluster cluster-name", msg.Title)
 	assert.Equal(t, fluxevent.EventAutoRelease, msg.Type)
 	assert.Equal(t, `Event: Automated release of justinbarrick/nginx:test3
 
@@ -185,10 +191,11 @@ func TestDefaultFormatterFormatUpdatePolicyEvent(t *testing.T) {
 		bodyTemplate:   bodyTemplate,
 		titleTemplate:  titleTemplate,
 		commitTemplate: commitTemplate,
+		cluster:        "cluster-name",
 	}
 	msg := d.FormatEvent(test_utils.NewFluxUpdatePolicyEvent(), &exporters.FakeExporter{})
 	assert.Equal(t, "https://github.com/commit/d644e1a05db6881abf0cdb78299917b95f442036", msg.TitleLink)
-	assert.Equal(t, "Applied flux changes to cluster", msg.Title)
+	assert.Equal(t, "Applied flux changes to cluster cluster-name", msg.Title)
 	assert.Equal(t, fluxevent.EventSync, msg.Type)
 	assert.Equal(t, `Event: Sync: d644e1a, default:deployment/test
 Commits:
@@ -206,13 +213,14 @@ func TestDefaultFormatterFormatSyncErrorEvent(t *testing.T) {
 		bodyTemplate:   bodyTemplate,
 		titleTemplate:  titleTemplate,
 		commitTemplate: commitTemplate,
+		cluster:        "cluster-name",
 	}
 
 	event := test_utils.NewFluxSyncErrorEvent()
 
 	msg := d.FormatEvent(event, &exporters.FakeExporter{})
 	assert.Equal(t, "https://github.com/commit/4997efcd4ac6255604d0d44eeb7085c5b0eb9d48", msg.TitleLink)
-	assert.Equal(t, "Applied flux changes to cluster", msg.Title)
+	assert.Equal(t, "Applied flux changes to cluster cluster-name", msg.Title)
 	assert.Equal(t, fluxevent.EventSync, msg.Type)
 	assert.Equal(t, `Event: Sync: 4997efc, default:persistentvolumeclaim/test
 Commits:


### PR DESCRIPTION
This PR adds the `cluster` config to the default formatter, and also to the default title template. This option only serves the purpose of allowing a method to identify the cluster where FluxCloud is running in the events, i.e., add cluster context to the events.