### PR TITLE
fix: disabling mattermost export by default

### DIFF
--- a/chart/fluxcloud/values.yaml
+++ b/chart/fluxcloud/values.yaml
@@ -116,7 +116,7 @@ config:
       key: ""
 
   mattermost:
-    enabled: true
+    enabled: false
     hook:
       # the Mattermost webhook URL to use.
       url: ""


### PR DESCRIPTION
Closes https://github.com/topfreegames/fluxcloud/issues/22